### PR TITLE
no, no, no, please do not print exit values!

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -9,4 +9,4 @@ source ~/.../lib/basics
 
 # This is a hackish thing. zsh restores print_exit_value after function calls,
 # so it's impossible to set it via anything above.
-setopt print_exit_value
+# setopt print_exit_value


### PR DESCRIPTION
Gross. :)

Really, this should only be set if the user has signaled it should be set, possibly through env or something.  I think "on" is the wrong default, but the real problem is that it shouldn't be impossible to override easily.  loop-dots should avoid all opinions

Meanwhile, I think I can override this in my zshrc and get on with life.
